### PR TITLE
Add requirements file and install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,22 @@ Typical fields:
 - Seaborn & Matplotlib
 - Jupyter Notebook
 
+## Setup
+
+Install the Python dependencies using `pip`:
+
+```bash
+pip install -r requirements.txt
+```
+
+### OS-level requirements
+
+For exporting plots to PDF you may need the `librsvg2-bin` package (Debian/Ubuntu):
+
+```bash
+sudo apt-get install librsvg2-bin
+```
+
 #Recommendations
 
 - Increase bike availability during morning and evening rush hours

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+pandas
+numpy
+seaborn
+matplotlib
+pingouin
+jupyter


### PR DESCRIPTION
## Summary
- create `requirements.txt`
- document installation steps and OS dependency for PDF export

## Testing
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6847c6ec1fdc83238205df00a55384ce