### PR TITLE
Add CI workflow and notebook cleanup instructions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install nbformat pytest
+      - name: Validate notebooks
+        run: |
+          python - <<'PY'
+import nbformat
+from pathlib import Path
+failed = False
+for nb in Path('.').rglob('*.ipynb'):
+    try:
+        with open(nb, 'r', encoding='utf-8') as f:
+            nbformat.read(f, as_version=4)
+    except Exception as e:
+        print(f"{nb}: {e}")
+        failed = True
+if failed:
+    raise SystemExit(1)
+PY
+      - name: Run tests
+        run: |
+          if [ -d tests ]; then pytest; else echo "No tests"; fi

--- a/README.md
+++ b/README.md
@@ -71,6 +71,15 @@ unzip data/yulu-bikeshare-dataset.zip -d data/
 jupyter notebook YULU-EDA-CaseStudy.ipynb
 ```
 
+4. To keep notebook outputs out of version control, install the `nbstripout` or
+   `pre-commit` hooks:
+
+```bash
+pip install nbstripout pre-commit
+nbstripout --install
+pre-commit install
+```
+
 The plots and tables will appear in the notebook's output cells after you run all sections.
 
 ### OS-level requirements


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to validate notebooks and run tests
- document how to install nbstripout or pre-commit hooks in the README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6847cc65ac408323a3478f3ecbbeca3d