### PR TITLE
Specify dependency versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-pandas
-numpy
-seaborn
-matplotlib
-pingouin
-jupyter
+pandas>=1.5
+numpy>=1.23
+seaborn>=0.12
+matplotlib>=3.6
+pingouin>=0.5
+jupyter>=1.0


### PR DESCRIPTION
## Summary
- specify minimal versions in `requirements.txt`

## Testing
- `pip install "pandas>=1.5" "numpy>=1.23" "seaborn>=0.12" "matplotlib>=3.6" "pingouin>=0.5" "jupyter>=1.0"`
- `python - <<'PY'
import pandas, numpy, seaborn, matplotlib, pingouin, jupyter
print('pandas', pandas.__version__)
print('numpy', numpy.__version__)
print('seaborn', seaborn.__version__)
print('matplotlib', matplotlib.__version__)
print('pingouin', pingouin.__version__)
PY
`

------
https://chatgpt.com/codex/tasks/task_e_6847d43422208323963b6471fe136911