### PR TITLE
Add pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+  - repo: https://github.com/kynan/nbstripout
+    rev: 0.6.1
+    hooks:
+      - id: nbstripout
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+  - repo: https://github.com/psf/black
+    rev: 23.11.0
+    hooks:
+      - id: black
+        language_version: python3

--- a/README.md
+++ b/README.md
@@ -71,14 +71,16 @@ unzip data/yulu-bikeshare-dataset.zip -d data/
 jupyter notebook YULU-EDA-CaseStudy.ipynb
 ```
 
-4. To keep notebook outputs out of version control, install the `nbstripout` or
-   `pre-commit` hooks:
+4. Enable the git hooks defined in `.pre-commit-config.yaml` so notebook
+   outputs are stripped and formatting checks run automatically:
 
 ```bash
-pip install nbstripout pre-commit
-nbstripout --install
+pip install pre-commit
 pre-commit install
 ```
+
+This configuration uses `nbstripout` under the hood to remove notebook output
+before each commit.
 
 The plots and tables will appear in the notebook's output cells after you run all sections.
 
@@ -103,4 +105,3 @@ sudo apt-get install librsvg2-bin
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-


### PR DESCRIPTION
## Summary
- add `.pre-commit-config.yaml`
- simplify README setup instructions to use `pre-commit install`

## Testing
- `pre-commit run --files README.md .pre-commit-config.yaml`

------
https://chatgpt.com/codex/tasks/task_e_6847d5b23a04832394ab1bdc935dd18b